### PR TITLE
Bug fix for ObjectEditor

### DIFF
--- a/plugins/devices/frontend-java/src/main/java/com/freedomotic/jfrontend/ObjectEditor.java
+++ b/plugins/devices/frontend-java/src/main/java/com/freedomotic/jfrontend/ObjectEditor.java
@@ -235,7 +235,6 @@ public class ObjectEditor
                 final JPanel sliderPanel = new JPanel(new FlowLayout());
                 final JSlider slider = new JSlider();
 
-                slider.setValue(rb.getValue());
                 slider.setMaximum(rb.getMax());
                 slider.setMinimum(rb.getMin());
                 slider.setPaintTicks(true);
@@ -245,6 +244,7 @@ public class ObjectEditor
                 //slider.setMinorTickSpacing(rb.getStep());
                 slider.setMajorTickSpacing(rb.getStep());
                 slider.setSnapToTicks(true);
+                slider.setValue(rb.getValue());
 
                 JLabel label = new JLabel(getBehaviorLabel(b));
                 tabControls.add(label);

--- a/plugins/devices/frontend-java/src/main/java/com/freedomotic/jfrontend/ObjectEditor.java
+++ b/plugins/devices/frontend-java/src/main/java/com/freedomotic/jfrontend/ObjectEditor.java
@@ -242,8 +242,14 @@ public class ObjectEditor
                 slider.setPaintLabels(false);
                 //slider.setMajorTickSpacing(rb.getScale() * 10);
                 //slider.setMinorTickSpacing(rb.getStep());
-                slider.setMajorTickSpacing(rb.getStep());
-                slider.setSnapToTicks(true);
+        		if ((rb.getMax() - rb.getMin()) / rb.getStep() < 10000) {
+        			slider.setMajorTickSpacing(rb.getStep());
+        			slider.setSnapToTicks(true);
+        		} else {
+        			// range is too wide, use 10000 ticks instead and don't snap
+        			slider.setMajorTickSpacing(10000);
+        			slider.setSnapToTicks(false);
+        		}
                 slider.setValue(rb.getValue());
 
                 JLabel label = new JLabel(getBehaviorLabel(b));
@@ -255,6 +261,15 @@ public class ObjectEditor
                     @Override
                     public void stateChanged(ChangeEvent e) {
                         if (!slider.getValueIsAdjusting()) {
+        					if (!slider.getSnapToTicks()) {
+        						// SnapToTicks disabled, snap to RangedIntBehavior step (round down to closest)
+        						int snapValue = slider.getValue() / rb.getStep() * rb.getStep();
+        						if (slider.getValue() != snapValue) {
+        							slider.setValue(snapValue);
+        							return;
+        						}
+        					}
+
                             Config params = new Config();
                             params.setProperty("value",
                                     String.valueOf(slider.getValue()));


### PR DESCRIPTION
For RangedIntBehavior values >100 or <0 (without scale), the slider value will be set to 100 or 0 respectively.
The slider value should be set only after defining slider max and min values.