### PR TITLE
Make SynchAction enum standalone

### DIFF
--- a/framework/freedomotic-core/src/main/java/com/freedomotic/core/SynchAction.java
+++ b/framework/freedomotic-core/src/main/java/com/freedomotic/core/SynchAction.java
@@ -1,0 +1,8 @@
+package com.freedomotic.core;
+
+public enum SynchAction {
+
+	CREATED, DELETED, UPDATED;
+
+	public static final String KEY_SYNCH_ACTION = "synch.action";
+}

--- a/framework/freedomotic-core/src/main/java/com/freedomotic/core/SynchManager.java
+++ b/framework/freedomotic-core/src/main/java/com/freedomotic/core/SynchManager.java
@@ -65,13 +65,13 @@ public class SynchManager implements BusConsumer {
                         Logger.getLogger(SynchManager.class.getName()).log(Level.SEVERE, null, ex);
                     }
                     // A new thing was created in another instance
-                    if (synchThingRequest.getProperty(SynchThingRequest.KEY_SYNCH_ACTION)
-                            .equalsIgnoreCase(SynchThingRequest.SynchAction.CREATED.name())) {
+                    if (synchThingRequest.getProperty(SynchAction.KEY_SYNCH_ACTION)
+                            .equalsIgnoreCase(SynchAction.CREATED.name())) {
                         thingsRepository.create(thing);
                     }
                     // A thing was deleted in another instance
-                    if (synchThingRequest.getProperty(SynchThingRequest.KEY_SYNCH_ACTION)
-                            .equalsIgnoreCase(SynchThingRequest.SynchAction.DELETED.name())) {
+                    if (synchThingRequest.getProperty(SynchAction.KEY_SYNCH_ACTION)
+                            .equalsIgnoreCase(SynchAction.DELETED.name())) {
                         thingsRepository.delete(thing);
                     }
                 }

--- a/framework/freedomotic-core/src/main/java/com/freedomotic/core/SynchThingRequest.java
+++ b/framework/freedomotic-core/src/main/java/com/freedomotic/core/SynchThingRequest.java
@@ -14,18 +14,11 @@ import com.freedomotic.model.object.EnvObject;
  */
 public class SynchThingRequest extends EventTemplate {
     
-    static final String KEY_SYNCH_ACTION = "synch.action";
-
     private final EnvObject thing;
-
-    public enum SynchAction {
-
-        CREATED, DELETED
-    };
 
     public SynchThingRequest(SynchAction action, EnvObject thing) {
         this.thing = thing;
-        this.addProperty("synch.action", action.name());
+        this.addProperty(SynchAction.KEY_SYNCH_ACTION, action.name());
     }
 
     public EnvObject getThing() {

--- a/framework/freedomotic-core/src/main/java/com/freedomotic/things/EnvObjectLogic.java
+++ b/framework/freedomotic-core/src/main/java/com/freedomotic/things/EnvObjectLogic.java
@@ -23,6 +23,7 @@ import com.freedomotic.behaviors.BehaviorLogic;
 import com.freedomotic.app.Freedomotic;
 import com.freedomotic.bus.BusService;
 import com.freedomotic.core.Resolver;
+import com.freedomotic.core.SynchAction;
 import com.freedomotic.core.SynchThingRequest;
 import com.freedomotic.environment.EnvironmentLogic;
 import com.freedomotic.environment.EnvironmentRepository;
@@ -41,9 +42,9 @@ import com.freedomotic.reactions.ReactionPersistence;
 import com.freedomotic.rules.Statement;
 import com.freedomotic.reactions.Trigger;
 import com.freedomotic.reactions.TriggerRepository;
-import com.freedomotic.things.ThingRepository.SynchAction;
 import com.freedomotic.util.TopologyUtils;
 import com.google.inject.Inject;
+
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -52,6 +53,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
 import org.apache.shiro.authz.annotation.RequiresPermissions;
 
 /**
@@ -231,11 +233,11 @@ public class EnvObjectLogic {
     public void setChanged(SynchAction action) {
         switch (action) {
             case CREATED:
-                SynchThingRequest creationEvent = new SynchThingRequest(SynchThingRequest.SynchAction.CREATED, getPojo());
+                SynchThingRequest creationEvent = new SynchThingRequest(SynchAction.CREATED, getPojo());
                 busService.send(creationEvent);
                 break;
             case DELETED:
-                SynchThingRequest deletionEvent = new SynchThingRequest(SynchThingRequest.SynchAction.DELETED, getPojo());
+                SynchThingRequest deletionEvent = new SynchThingRequest(SynchAction.DELETED, getPojo());
                 busService.send(deletionEvent);
                 break;
             case UPDATED:

--- a/framework/freedomotic-core/src/main/java/com/freedomotic/things/ThingRepository.java
+++ b/framework/freedomotic-core/src/main/java/com/freedomotic/things/ThingRepository.java
@@ -17,11 +17,6 @@ import java.util.List;
  */
 public interface ThingRepository extends Repository<EnvObjectLogic> {
 
-    public enum SynchAction {
-
-        CREATED, DELETED, UPDATED
-    };
-
     public List<EnvObjectLogic> findByEnvironment(EnvironmentLogic env);
 
     public List<EnvObjectLogic> findByEnvironment(String uuid);

--- a/framework/freedomotic-core/src/main/java/com/freedomotic/things/impl/ThingRepositoryImpl.java
+++ b/framework/freedomotic-core/src/main/java/com/freedomotic/things/impl/ThingRepositoryImpl.java
@@ -19,6 +19,7 @@
  */
 package com.freedomotic.things.impl;
 
+import com.freedomotic.core.SynchAction;
 import com.freedomotic.environment.EnvironmentLogic;
 import com.freedomotic.exceptions.DataUpgradeException;
 import com.freedomotic.exceptions.RepositoryException;
@@ -34,6 +35,7 @@ import com.freedomotic.settings.Info;
 import com.freedomotic.util.SerialClone;
 import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.XStreamException;
+
 import java.io.File;
 import java.io.FileFilter;
 import java.io.FileInputStream;
@@ -48,7 +50,9 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.UUID;
+
 import javax.inject.Inject;
+
 import org.apache.shiro.authz.annotation.RequiresPermissions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;


### PR DESCRIPTION
SynchAction is specified as inner enum in both ThingRepository and SynchThingRequest.
Make it standalone and change where required in those classes.