### PR TITLE
Fix Core-539 - Lower or upper bound values won't change RangedIntBehaviors

### DIFF
--- a/framework/freedomotic-core/src/main/java/com/freedomotic/behaviors/RangedIntBehaviorLogic.java
+++ b/framework/freedomotic-core/src/main/java/com/freedomotic/behaviors/RangedIntBehaviorLogic.java
@@ -177,11 +177,15 @@ public class RangedIntBehaviorLogic
             if (tmpValue <= getMin()) {
                 params.setProperty("value",
                         Integer.valueOf(getMin()).toString());
+                params.setProperty("value.original",
+                        Integer.valueOf(tmpValue).toString());
                 listener.onLowerBoundValue(params, fireCommand);
             } else {
                 if (tmpValue >= getMax()) {
                     params.setProperty("value",
                             String.valueOf(getMax()));
+                    params.setProperty("value.original",
+                            Integer.valueOf(tmpValue).toString());
                     listener.onUpperBoundValue(params, fireCommand);
                 } else {
                     listener.onRangeValue(tmpValue, params, fireCommand);

--- a/plugins/objects/base-things/src/main/java/com/freedomotic/things/impl/GenericSensor.java
+++ b/plugins/objects/base-things/src/main/java/com/freedomotic/things/impl/GenericSensor.java
@@ -51,12 +51,22 @@ public class GenericSensor
         readValue.addListener(new RangedIntBehaviorLogic.Listener() {
             @Override
             public void onLowerBoundValue(Config params, boolean fireCommand) {
-                //there is an hardware read error
+            	if (params.getProperty("value.original").equals(params.getProperty("value"))) {
+//ok here, just trying to set minimum                	
+            		onRangeValue(readValue.getMin(), params, fireCommand);
+            	} else {
+//there is an hardware read error
+            	}
             }
 
             @Override
             public void onUpperBoundValue(Config params, boolean fireCommand) {
-                //there is as hardware read error
+            	if (params.getProperty("value.original").equals(params.getProperty("value"))) {
+//ok here, just trying to set maximum                	
+            		onRangeValue(readValue.getMax(), params, fireCommand);
+            	} else {
+//there is an hardware read error
+            	}
             }
 
             @Override

--- a/plugins/objects/base-things/src/main/java/com/freedomotic/things/impl/PowerMeter.java
+++ b/plugins/objects/base-things/src/main/java/com/freedomotic/things/impl/PowerMeter.java
@@ -23,7 +23,6 @@
 package com.freedomotic.things.impl;
 
 import com.freedomotic.things.impl.ElectricDevice;
-import com.freedomotic.app.Freedomotic;
 import com.freedomotic.model.ds.Config;
 import com.freedomotic.model.object.RangedIntBehavior;
 import com.freedomotic.behaviors.RangedIntBehaviorLogic;
@@ -46,12 +45,22 @@ public class PowerMeter
         current.addListener(new RangedIntBehaviorLogic.Listener() {
             @Override
             public void onLowerBoundValue(Config params, boolean fireCommand) {
-                //there is an hardware read error
+            	if (params.getProperty("value.original").equals(params.getProperty("value"))) {
+//ok here, just trying to set minimum                	
+            		onRangeValue(current.getMin(), params, fireCommand);
+            	} else {
+//there is an hardware read error
+            	}
             }
 
             @Override
             public void onUpperBoundValue(Config params, boolean fireCommand) {
-                //there is as hardware read error
+            	if (params.getProperty("value.original").equals(params.getProperty("value"))) {
+//ok here, just trying to set maximum                	
+            		onRangeValue(current.getMax(), params, fireCommand);
+            	} else {
+//there is an hardware read error
+            	}
             }
 
             @Override
@@ -70,12 +79,22 @@ public class PowerMeter
         voltage.addListener(new RangedIntBehaviorLogic.Listener() {
             @Override
             public void onLowerBoundValue(Config params, boolean fireCommand) {
-                //there is an hardware read error
+            	if (params.getProperty("value.original").equals(params.getProperty("value"))) {
+//ok here, just trying to set minimum                	
+            		onRangeValue(voltage.getMin(), params, fireCommand);
+            	} else {
+//there is an hardware read error
+            	}
             }
 
             @Override
             public void onUpperBoundValue(Config params, boolean fireCommand) {
-                //there is as hardware read error
+            	if (params.getProperty("value.original").equals(params.getProperty("value"))) {
+//ok here, just trying to set maximum                	
+            		onRangeValue(voltage.getMax(), params, fireCommand);
+            	} else {
+//there is an hardware read error
+            	}
             }
 
             @Override
@@ -94,12 +113,22 @@ public class PowerMeter
         power.addListener(new RangedIntBehaviorLogic.Listener() {
             @Override
             public void onLowerBoundValue(Config params, boolean fireCommand) {
-                //there is an hardware read error
+            	if (params.getProperty("value.original").equals(params.getProperty("value"))) {
+//ok here, just trying to set minimum                	
+            		onRangeValue(power.getMin(), params, fireCommand);
+            	} else {
+//there is an hardware read error
+            	}
             }
 
             @Override
             public void onUpperBoundValue(Config params, boolean fireCommand) {
-                //there is as hardware read error
+            	if (params.getProperty("value.original").equals(params.getProperty("value"))) {
+//ok here, just trying to set maximum                	
+            		onRangeValue(power.getMax(), params, fireCommand);
+            	} else {
+//there is an hardware read error
+            	}
             }
 
             @Override
@@ -118,12 +147,22 @@ public class PowerMeter
         powerFactor.addListener(new RangedIntBehaviorLogic.Listener() {
             @Override
             public void onLowerBoundValue(Config params, boolean fireCommand) {
-                //there is an hardware read error
+            	if (params.getProperty("value.original").equals(params.getProperty("value"))) {
+//ok here, just trying to set minimum                	
+            		onRangeValue(powerFactor.getMin(), params, fireCommand);
+            	} else {
+//there is an hardware read error
+            	}
             }
 
             @Override
             public void onUpperBoundValue(Config params, boolean fireCommand) {
-                //there is as hardware read error
+            	if (params.getProperty("value.original").equals(params.getProperty("value"))) {
+//ok here, just trying to set maximum                	
+            		onRangeValue(powerFactor.getMax(), params, fireCommand);
+            	} else {
+//there is an hardware read error
+            	}
             }
 
             @Override
@@ -142,12 +181,22 @@ public class PowerMeter
         energy.addListener(new RangedIntBehaviorLogic.Listener() {
             @Override
             public void onLowerBoundValue(Config params, boolean fireCommand) {
-                //there is an hardware read error
+            	if (params.getProperty("value.original").equals(params.getProperty("value"))) {
+//ok here, just trying to set minimum                	
+            		onRangeValue(energy.getMin(), params, fireCommand);
+            	} else {
+//there is an hardware read error
+            	}
             }
 
             @Override
             public void onUpperBoundValue(Config params, boolean fireCommand) {
-                //there is as hardware read error
+            	if (params.getProperty("value.original").equals(params.getProperty("value"))) {
+//ok here, just trying to set maximum                	
+            		onRangeValue(energy.getMax(), params, fireCommand);
+            	} else {
+//there is an hardware read error
+            	}
             }
 
             @Override

--- a/plugins/objects/base-things/src/main/java/com/freedomotic/things/impl/StepperMotor.java
+++ b/plugins/objects/base-things/src/main/java/com/freedomotic/things/impl/StepperMotor.java
@@ -44,11 +44,23 @@ public class StepperMotor
             @Override
             public void onLowerBoundValue(Config params, boolean fireCommand) {
                 //turnPowerOff(params);
+            	if (params.getProperty("value.original").equals(params.getProperty("value"))) {
+//ok here, just trying to set minimum                	
+            		onRangeValue(position.getMin(), params, fireCommand);
+            	} else {
+//there is an hardware read error
+            	}
             }
 
             @Override
             public void onUpperBoundValue(Config params, boolean fireCommand) {
                 //turnPowerOn(params);
+            	if (params.getProperty("value.original").equals(params.getProperty("value"))) {
+//ok here, just trying to set maximum                	
+            		onRangeValue(position.getMax(), params, fireCommand);
+            	} else {
+//there is an hardware read error
+            	}
             }
 
             @Override

--- a/plugins/objects/base-things/src/main/java/com/freedomotic/things/impl/Thermometer.java
+++ b/plugins/objects/base-things/src/main/java/com/freedomotic/things/impl/Thermometer.java
@@ -45,12 +45,22 @@ public class Thermometer
         temperature.addListener(new RangedIntBehaviorLogic.Listener() {
             @Override
             public void onLowerBoundValue(Config params, boolean fireCommand) {
+            	if (params.getProperty("value.original").equals(params.getProperty("value"))) {
+//ok here, just trying to set minimum
+            		onRangeValue(temperature.getMin(), params, fireCommand);
+            	} else {
 //there is an hardware read error
+            	}
             }
 
             @Override
             public void onUpperBoundValue(Config params, boolean fireCommand) {
-//there is as hardware read error
+            	if (params.getProperty("value.original").equals(params.getProperty("value"))) {
+//ok here, just trying to set maximum
+            		onRangeValue(temperature.getMax(), params, fireCommand);
+            	} else {
+//there is an hardware read error
+            	}
             }
 
             @Override

--- a/plugins/objects/tv/src/main/java/com/freedomotic/objects/impl/TV.java
+++ b/plugins/objects/tv/src/main/java/com/freedomotic/objects/impl/TV.java
@@ -56,11 +56,13 @@ public class TV extends ElectricDevice {
             @Override
             public void onLowerBoundValue(Config params, boolean fireCommand) {
                 //turnPowerOff(params);
+            	onRangeValue(volume.getMin(), params, fireCommand)
             }
 
             @Override
             public void onUpperBoundValue(Config params, boolean fireCommand) {
                 //turnPowerOn(params);
+            	onRangeValue(volume.getMax(), params, fireCommand)
             }
 
             @Override
@@ -80,10 +82,12 @@ public class TV extends ElectricDevice {
         channel.addListener(new RangedIntBehaviorLogic.Listener() {
             @Override
             public void onLowerBoundValue(Config params, boolean fireCommand) {
+            	onRangeValue(channel.getMin(), params, fireCommand)
             }
 
             @Override
             public void onUpperBoundValue(Config params, boolean fireCommand) {
+            	onRangeValue(channel.getMax(), params, fireCommand)
             }
 
             @Override


### PR DESCRIPTION
- In RangedIntBehaviorLogic, a new property "value.original" was created (so it won't break existing object plugins);
- Some object plugins were changed to use the new property (if "value" and "value.original" are equal, we want to set the min/max value; only if they are different consider "hardware error").

This fix also allows to detect and notify about out of range values ("value" and "value.original" different), offering the functionality required by Core-536.
Before this fix, an object like a Thermometer wouldn't do anything upon receiving a min or max value:
       public void onLowerBoundValue(Config params, boolean fireCommand) {
                //there is an hardware read error
            }