### PR TITLE
Fix Core-542 - we should check if the new name exists, not the template

### DIFF
--- a/framework/freedomotic-core/src/main/java/com/freedomotic/things/impl/ThingRepositoryImpl.java
+++ b/framework/freedomotic-core/src/main/java/com/freedomotic/things/impl/ThingRepositoryImpl.java
@@ -404,7 +404,7 @@ class ThingRepositoryImpl implements ThingRepository {
     private String getNextInOrder(String name) {
         String newName = name;
         int i = 0;
-        while (!this.findByName(name).isEmpty() && (i < 1000)) {
+        while (!this.findByName(newName).isEmpty() && (i < 1000)) {
             // i < 1000 just to avoid infinite loop in case of errors
             i++;
             newName = name + "-" + i;


### PR DESCRIPTION
Otherwise, the first object gets named <object>, the second <object>-1000 and the third causes a runtime exception (because it was also going to be called <object>-1000 and we cannot add the same object more than one time)