### PR TITLE
Fixes for controls layout on Object Editor

### DIFF
--- a/data-example/furn/df28cda0-a866-11e2-9e96-0800200c9a66/data/obj/cb02d463-070b-47ac-a98d-1f0e1e95fd30.xobj
+++ b/data-example/furn/df28cda0-a866-11e2-9e96-0800200c9a66/data/obj/cb02d463-070b-47ac-a98d-1f0e1e95fd30.xobj
@@ -29,7 +29,7 @@
       <max>0</max>
       <min>0</min>
       <scale>1</scale>
-      <step>0</step>
+      <step>1</step>
     </com.freedomotic.model.object.RangedIntBehavior>
   </behaviors>
   <representation>

--- a/plugins/devices/frontend-java/src/main/java/com/freedomotic/jfrontend/ObjectEditor.java
+++ b/plugins/devices/frontend-java/src/main/java/com/freedomotic/jfrontend/ObjectEditor.java
@@ -244,10 +244,12 @@ public class ObjectEditor
                 slider.setPaintTicks(true);
                 slider.setPaintTrack(true);
                 slider.setPaintLabels(false);
+                int step = rb.getStep();
+                if (step == 0) step = 1;
                 //slider.setMajorTickSpacing(rb.getScale() * 10);
                 //slider.setMinorTickSpacing(rb.getStep());
-        		if ((rb.getMax() - rb.getMin()) / rb.getStep() < 10000) {
-        			slider.setMajorTickSpacing(rb.getStep());
+        		if ((rb.getMax() - rb.getMin()) / step < 10000) {
+        			slider.setMajorTickSpacing(step);
         			slider.setSnapToTicks(true);
         		} else {
         			// range is too wide, use 10000 ticks instead and don't snap

--- a/plugins/devices/frontend-java/src/main/java/com/freedomotic/jfrontend/ObjectEditor.java
+++ b/plugins/devices/frontend-java/src/main/java/com/freedomotic/jfrontend/ObjectEditor.java
@@ -194,13 +194,13 @@ public class ObjectEditor
         tabControls.removeAll();
 
         //tabControls.setLayout(new BoxLayout(tabControls, BoxLayout.PAGE_AXIS));
-        tabControls.setLayout(new GridLayout(Iterators.size(object.getBehaviors().iterator()), 2));
-
-        //create an array of controllers for the object behaviors
-        int row = 0;
+        tabControls.setLayout(new GridLayout(Iterators.size(object.getBehaviors().iterator()),1));
 
         for (Behavior behavior : object.getPojo().getBehaviors()) {
-            // All this is done just to keep the behavior orders as in pojo definition
+        	JPanel rowPanel = new JPanel();
+        	rowPanel.setLayout(new GridLayout());
+        	
+        	// All this is done just to keep the behavior orders as in pojo definition
             BehaviorLogic b = object.getBehavior(behavior.getName());
             if (b instanceof BooleanBehaviorLogic) {
                 final BooleanBehaviorLogic bb = (BooleanBehaviorLogic) b;
@@ -213,8 +213,9 @@ public class ObjectEditor
                 }
 
                 JLabel label = new JLabel(getBehaviorLabel(b));
-                tabControls.add(label);
-                tabControls.add(button);
+                rowPanel.add(label);
+                rowPanel.add(button);
+                tabControls.add(rowPanel);
                 button.addActionListener(new ActionListener() {
                     @Override
                     public void actionPerformed(ActionEvent e) {
@@ -256,10 +257,11 @@ public class ObjectEditor
                 slider.setValue(rb.getValue());
 
                 JLabel label = new JLabel(getBehaviorLabel(b));
-                tabControls.add(label);
+                rowPanel.add(label);
                 sliderPanel.add(slider);
                 sliderPanel.add(doubleValue);
-                tabControls.add(sliderPanel);
+                rowPanel.add(sliderPanel);
+                tabControls.add(rowPanel);
                 // if slider is enabled, add a popup to allow user to write values
         		if (!b.isReadOnly()) 
         			slider.addMouseListener(new SliderPopup(slider, rb));
@@ -305,8 +307,9 @@ public class ObjectEditor
                 comboBox.setSelectedItem(lb.getSelected());
 
                 JLabel label = new JLabel(getBehaviorLabel(b));
-                tabControls.add(label);
-                tabControls.add(comboBox);
+                rowPanel.add(label);
+                rowPanel.add(comboBox);
+                tabControls.add(rowPanel);
                 comboBox.addActionListener(new ActionListener() {
                     @Override
                     public void actionPerformed(ActionEvent e) {
@@ -655,7 +658,6 @@ public class ObjectEditor
 
         tabObjectEditor.addTab(I18n.msg("appearance"), tabRepresentation);
 
-        tabControls.setLayout(new java.awt.BorderLayout());
         tabObjectEditor.addTab(I18n.msg("control_panel"), tabControls);
 
         tabAutomations.setLayout(new java.awt.BorderLayout());
@@ -1114,11 +1116,14 @@ public class ObjectEditor
             }
         });
         refreshMultiselectionList(lb, list);
-        tabControls.add(label);
-        tabControls.add(list);
-        tabControls.add(newItem);
-        tabControls.add(btnAdd);
-        tabControls.add(btnRemove);
+    	JPanel rowPanel = new JPanel();
+    	rowPanel.setLayout(new GridLayout());
+    	rowPanel.add(label);
+        rowPanel.add(list);
+        rowPanel.add(newItem);
+        rowPanel.add(btnAdd);
+        rowPanel.add(btnRemove);
+        tabControls.add(rowPanel);
         tabControls.validate();
     }
 


### PR DESCRIPTION
If we have a MultiSelection List and controls for other behaviors, like a button for Boolean, everything gets messed up.
Also, a Thermostat in data example has a step value of 0, which causes an error.