### PR TITLE
Fd fix multi selection

### DIFF
--- a/framework/freedomotic-core/src/main/java/com/freedomotic/behaviors/TaxonomyBehaviorLogic.java
+++ b/framework/freedomotic-core/src/main/java/com/freedomotic/behaviors/TaxonomyBehaviorLogic.java
@@ -20,10 +20,10 @@
  */
 package com.freedomotic.behaviors;
 
+import java.util.List;
+
 import com.freedomotic.model.ds.Config;
 import com.freedomotic.model.object.MultiselectionListBehavior;
-import java.util.List;
-import java.util.logging.Logger;
 
 /**
  * This behavior accepts a string which is an element of the list or "next" or
@@ -94,17 +94,17 @@ public class TaxonomyBehaviorLogic
             listener.onAdd(params, fireCommand);
         } else {
             if (value.equalsIgnoreCase("remove")) {
-                //data.setUnselected(item);
+                data.setUnselected(item);
                 listener.onRemove(params, fireCommand);
             } else {
                 if (value.equalsIgnoreCase("true") || value.equalsIgnoreCase("selected") || value.equals("1")) {
-                    //data.setSelected(item);
+                    data.setSelected(item);
                     listener.onSelection(params, fireCommand);
                 } else {
                     if (value.equalsIgnoreCase("false")
                             || value.equalsIgnoreCase("unselected")
                             || value.equals("0")) {
-                        //data.setUnselected(item);
+                        data.setUnselected(item);
                         listener.onUnselection(params, fireCommand);
                     }
                 }
@@ -247,5 +247,5 @@ public class TaxonomyBehaviorLogic
     public void setChanged(boolean value) {
         changed = value;
     }
-    private static final Logger LOG = Logger.getLogger(TaxonomyBehaviorLogic.class.getName());
+
 }

--- a/framework/freedomotic-core/src/main/java/com/freedomotic/behaviors/TaxonomyBehaviorLogic.java
+++ b/framework/freedomotic-core/src/main/java/com/freedomotic/behaviors/TaxonomyBehaviorLogic.java
@@ -94,17 +94,17 @@ public class TaxonomyBehaviorLogic
             listener.onAdd(params, fireCommand);
         } else {
             if (value.equalsIgnoreCase("remove")) {
-                data.setUnselected(item);
+                setUnselected(item);
                 listener.onRemove(params, fireCommand);
             } else {
                 if (value.equalsIgnoreCase("true") || value.equalsIgnoreCase("selected") || value.equals("1")) {
-                    data.setSelected(item);
+                    setSelected(item);
                     listener.onSelection(params, fireCommand);
                 } else {
                     if (value.equalsIgnoreCase("false")
                             || value.equalsIgnoreCase("unselected")
                             || value.equals("0")) {
-                        data.setUnselected(item);
+                        setUnselected(item);
                         listener.onUnselection(params, fireCommand);
                     }
                 }
@@ -139,8 +139,7 @@ public class TaxonomyBehaviorLogic
      * @param item
      */
     protected void setSelected(String item) {
-        if (!data.getSelected().equals(item)) {
-            data.setSelected(item);
+        if (data.setSelected(item)) {
             setChanged(true);
         }
     }
@@ -150,8 +149,7 @@ public class TaxonomyBehaviorLogic
      * @param item
      */
     protected void setUnselected(String item) {
-        if (data.getSelected().equals(item)) {
-            data.setUnselected(item);
+        if (data.setUnselected(item)) {
             setChanged(true);
         }
     }

--- a/framework/freedomotic-model/src/main/java/com/freedomotic/model/object/MultiselectionListBehavior.java
+++ b/framework/freedomotic-model/src/main/java/com/freedomotic/model/object/MultiselectionListBehavior.java
@@ -101,21 +101,27 @@ public class MultiselectionListBehavior
     /**
      *
      * @param key
+     * @return key selected (boolean)
      */
-    public void setSelected(String key) {
+    public boolean setSelected(String key) {
         if (list.contains(key) && !selected.contains(key)) {
             selected.add(key);
+            return true;
         }
+        return false;
     }
 
     /**
      *
      * @param key
+     * @return key unselected (boolean)
      */
-    public void setUnselected(String key) {
+    public boolean setUnselected(String key) {
         if (list.contains(key) && selected.contains(key)) {
             selected.remove(key);
+            return true;
         }
+        return false;
     }
 
     /**

--- a/plugins/devices/frontend-java/src/main/java/com/freedomotic/jfrontend/ObjectEditor.java
+++ b/plugins/devices/frontend-java/src/main/java/com/freedomotic/jfrontend/ObjectEditor.java
@@ -1129,6 +1129,7 @@ public class ObjectEditor
             final JCheckBox box = new JCheckBox(item);
 
             if (!model.contains(box)) { //no duplicates allowed
+            	box.setSelected(source.getSelected().contains(item));
                 box.addChangeListener(new ChangeListener() {
                     public void stateChanged(ChangeEvent e) {
                         Config params = new Config();
@@ -1139,7 +1140,6 @@ public class ObjectEditor
                         source.filterParams(params, true);
                     }
                 });
-                box.setSelected(source.getSelected().contains(item));
                 model.addElement(box);
             }
         }


### PR DESCRIPTION
TaxonomyBehaviorLogic / MultiselectionListBehaviors were not working.
For now, uncomment lines in TaxonomyBehaviorLogic so elements can be selected.
Also fix the corresponding section in ObjectEditor: set the box selection status before adding a change listener, otherwise a crazy loop of stateChanged->setChanged is created.