### PR TITLE
Fix for failing test #168

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,3 @@
 language: java
+jdk:
+  - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: java

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: java
+script: mvn test -Djava.net.preferIPv4Stack=true
 jdk:
   - oraclejdk8

--- a/framework/freedomotic-core/src/test/java/com/freedomotic/core/CommandsNlpServiceTest.java
+++ b/framework/freedomotic-core/src/test/java/com/freedomotic/core/CommandsNlpServiceTest.java
@@ -105,9 +105,7 @@ public class CommandsNlpServiceTest {
         String phrase = "asdasd tretert gbffdg uyututy mnbb";
         // Compute the commands ranking
         List<Nlp.Rank<Command>> ranking = nlpCommand.computeSimilarity(phrase, 10);
-        for(Nlp.Rank<Command> r:ranking){
-            System.out.println(r.getElement().toString());
-        }
+      
         assertEquals("Should find a command anyway, because zero similarity is allowed", 1, ranking.size());
         assertEquals("The command should be totally different from anyone else in the repository", 0, ranking.get(0).getSimilarity());
     }

--- a/framework/freedomotic-core/src/test/java/com/freedomotic/core/CommandsNlpServiceTest.java
+++ b/framework/freedomotic-core/src/test/java/com/freedomotic/core/CommandsNlpServiceTest.java
@@ -65,6 +65,10 @@ public class CommandsNlpServiceTest {
 
     @Before
     public void setUp() {
+        // Fix for failing test:
+        commandRepository.deleteAll();
+
+
         Command command = new Command();
         command.setName("Turn on kitchen light");
         command.setReceiver("app.events.sensors.behavior.request.objects");
@@ -76,7 +80,8 @@ public class CommandsNlpServiceTest {
 
     @After
     public void tearDown() {
-        commandRepository.deleteAll();
+        // DeleteAll  is done on setup
+        //commandRepository.deleteAll();
     }
 
     /**
@@ -100,6 +105,9 @@ public class CommandsNlpServiceTest {
         String phrase = "asdasd tretert gbffdg uyututy mnbb";
         // Compute the commands ranking
         List<Nlp.Rank<Command>> ranking = nlpCommand.computeSimilarity(phrase, 10);
+        for(Nlp.Rank<Command> r:ranking){
+            System.out.println(r.getElement().toString());
+        }
         assertEquals("Should find a command anyway, because zero similarity is allowed", 1, ranking.size());
         assertEquals("The command should be totally different from anyone else in the repository", 0, ranking.get(0).getSimilarity());
     }


### PR DESCRIPTION
Moved "commandRepository.deleteAll()" from "tearDown" to "setup" to be sure to always start with a clean repo
Otherwise the repository could contain "old" objects from prior tests (e.g. mvn test)