### PR TITLE
Improve http response content processing in HttpHelper

### DIFF
--- a/framework/freedomotic-core/pom.xml
+++ b/framework/freedomotic-core/pom.xml
@@ -140,6 +140,13 @@
             <artifactId>mockserver-netty</artifactId>
             <version>3.10.4</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <!-- excluded because problems DOM parsing, see https://github.com/freedomotic/freedomotic/pull/183 -->
+                    <groupId>xerces</groupId>
+                    <artifactId>xercesImpl</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/framework/freedomotic-core/pom.xml
+++ b/framework/freedomotic-core/pom.xml
@@ -136,6 +136,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mock-server</groupId>
+            <artifactId>mockserver-netty</artifactId>
+            <version>3.10.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>18.0</version>

--- a/framework/freedomotic-core/src/test/java/com/freedomotic/helpers/HttpHelperTest.java
+++ b/framework/freedomotic-core/src/test/java/com/freedomotic/helpers/HttpHelperTest.java
@@ -1,0 +1,91 @@
+package com.freedomotic.helpers;
+
+import org.apache.http.HttpStatus;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockserver.client.server.MockServerClient;
+import org.mockserver.junit.MockServerRule;
+import org.mockserver.model.Header;
+
+import java.nio.charset.Charset;
+
+import static org.apache.commons.codec.binary.Base64.encodeBase64String;
+import static org.apache.http.HttpStatus.SC_OK;
+import static org.junit.Assert.assertEquals;
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
+
+public class HttpHelperTest {
+
+    private static final String A_USERNAME = "user";
+    private static final String A_PASSWORD = "password";
+    private static final String A_PATH = "/everything";
+    private static final String OK_RESPONSE = "OK";
+    public static final int RANDOM_PORT = 0;
+
+    private HttpHelper httpHelper;
+
+    @Rule
+    public MockServerRule mockServerRule = new MockServerRule(RANDOM_PORT);
+
+    private MockServerClient mockServerClient;
+    private String baseUrl;
+
+    @Before
+    public void setUp() throws Exception {
+        httpHelper = new HttpHelper();
+        Integer port = mockServerRule.getPort();
+//        port = 9090;
+        baseUrl = "http://localhost:" + port + A_PATH;
+        mockServerClient = new MockServerClient("127.0.0.1", mockServerRule.getPort());
+    }
+
+    @After
+    public void tearDown() throws Exception {
+
+    }
+
+    @Test
+    public void usernameAndPasswordAreSendWithRequest() throws Exception {
+        respondWhenBasicAuthIsGiven(SC_OK, OK_RESPONSE);
+        respond401WhenNoBasicAuthenticationIsGiven();
+
+        String content = httpHelper.retrieveContent(baseUrl, A_USERNAME, A_PASSWORD);
+
+        assertEquals(OK_RESPONSE, content);
+    }
+
+    private void respondWhenBasicAuthIsGiven(int responseStatusCode, String response) {
+        mockServerClient.when(
+                request()
+                        .withMethod("GET")
+                        .withHeader(new Header("Authorization", "Basic " + asBasicAuthString()))
+                        .withPath(A_PATH)
+        )
+                .respond(
+                        response()
+                                .withStatusCode(responseStatusCode)
+                                .withBody(response)
+                );
+    }
+
+    private void respond401WhenNoBasicAuthenticationIsGiven() {
+        mockServerClient.when(
+                request()
+                        .withMethod("GET")
+                        .withPath(A_PATH)
+        )
+                .respond(
+                        response()
+                                .withStatusCode(HttpStatus.SC_UNAUTHORIZED)
+                                .withHeader(new Header("WWW-Authenticate", "Basic realm=\"Realm\""))
+                );
+    }
+
+    private static String asBasicAuthString() {
+        return encodeBase64String((A_USERNAME + ":" + A_PASSWORD).getBytes(Charset.forName("ASCII")));
+    }
+
+}

--- a/framework/freedomotic-core/src/test/java/com/freedomotic/helpers/HttpHelperTest.java
+++ b/framework/freedomotic-core/src/test/java/com/freedomotic/helpers/HttpHelperTest.java
@@ -1,7 +1,6 @@
 package com.freedomotic.helpers;
 
 import org.apache.http.HttpStatus;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -35,16 +34,11 @@ public class HttpHelperTest {
 
     @Before
     public void setUp() throws Exception {
-        httpHelper = new HttpHelper();
         Integer port = mockServerRule.getPort();
-//        port = 9090;
+        mockServerClient = new MockServerClient("localhost", mockServerRule.getPort());
+
+        httpHelper = new HttpHelper();
         baseUrl = "http://localhost:" + port + A_PATH;
-        mockServerClient = new MockServerClient("127.0.0.1", mockServerRule.getPort());
-    }
-
-    @After
-    public void tearDown() throws Exception {
-
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -277,6 +277,14 @@
                     <goals>deploy</goals>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.19</version>
+                <configuration>
+                    <runOrder>hourly</runOrder>
+                </configuration>
+            </plugin>
         </plugins>   
         
         <!-- Preconfigure this plugin for child projects (called if the child have specified it in its pom)-->


### PR DESCRIPTION
Hi,

I stumbled upon #Hacktoberfest and wanted to solve issue #163 .
Instead of adding POST method support, I fixed some other things:

* String encoding is parsed from HttpResponse, to avoid character conversion problems
* replace DefaultHttpClient, because its deprecated
* use raw byte[] for XML parsing, in order to preserve correct XML character encoding
* added unit tests

I think this is already very useful for freedomotic and thus I've created this PR.

Feedback is welcome.

Regards
Martin