### PR TITLE
[core] fix typo

### DIFF
--- a/framework/freedomotic-core/src/main/java/com/freedomotic/core/Resolver.java
+++ b/framework/freedomotic-core/src/main/java/com/freedomotic/core/Resolver.java
@@ -221,7 +221,7 @@ public final class Resolver {
                     String script = possibleScript.substring(1); //removing equal sign on the head
 
                     if (js == null) {
-                        LOG.error("Cannot instatiate a JavaScript engine");
+                        LOG.error("Cannot instantiate a JavaScript engine");
                     }
 
                     try {


### PR DESCRIPTION
:bug: label: [hacktoberfest](https://hacktoberfest.digitalocean.com)

Greetings,

The word ‘instatiate’ is not in the English language and can easily be explained away as a typo. The error message is more easily understood with a proper spelling; therefore, we believe the word should be corrected to 'instantiate.'

Signed-off-by: Bryon Gloden, CISSP® cissp@bryongloden.com