### PR TITLE
[settings] Field isn't final but should be

### DIFF
--- a/framework/freedomotic-core/src/main/java/com/freedomotic/settings/Info.java
+++ b/framework/freedomotic-core/src/main/java/com/freedomotic/settings/Info.java
@@ -41,9 +41,9 @@ import org.slf4j.LoggerFactory;
 public class Info {
 
     private static final Logger LOG = LoggerFactory.getLogger(Info.class.getName());
-    public static FrameworkSettings FRAMEWORK = new FrameworkSettings();
-    public static PathSettings PATHS = new PathSettings();
-    public static MessagingSettings MESSAGING = new MessagingSettings();
+    public static final FrameworkSettings FRAMEWORK = new FrameworkSettings();
+    public static final PathSettings PATHS = new PathSettings();
+    public static final MessagingSettings MESSAGING = new MessagingSettings();
 
     @XmlRootElement
     @XmlAccessorType(XmlAccessType.FIELD)


### PR DESCRIPTION
:bug: label: [hacktoberfest](https://hacktoberfest.digitalocean.com)

Greetings,

This `static` field `public` but not `final`, and could be changed by malicious code or by accident from another package. The field could be made `final` to avoid this vulnerability.

Signed-off-by: Bryon Gloden, CISSP® cissp@bryongloden.com

