### PR TITLE
Fix #147 Add missing default.file appender configuration

### DIFF
--- a/framework/freedomotic-core/src/main/resources/log4j.properties
+++ b/framework/freedomotic-core/src/main/resources/log4j.properties
@@ -16,6 +16,13 @@ log4j.appender.console.threshold=INFO
 log4j.appender.console.layout=org.apache.log4j.PatternLayout
 log4j.appender.console.layout.ConversionPattern=%-5p [%t] - %m%n
 
+# file appender
+log4j.appender.default.file=org.apache.log4j.FileAppender
+log4j.appender.default.file.append=true
+log4j.appender.default.file.file=log/freedomotic.log
+log4j.appender.default.file.threshold=INFO
+log4j.appender.default.file.layout=org.apache.log4j.PatternLayout
+log4j.appender.default.file.layout.ConversionPattern=%-5p [%t] - %m%n
 
 #concrete loggers
 log4j.logger.org.apache.activemq=INFO, console


### PR DESCRIPTION
This PR adds missing `default.file` appender configuration. It use the same conversion pattern as `console` appender.