### PR TITLE
Improve logging in mqttclient plugin

### DIFF
--- a/plugins/devices/mqtt-client/src/main/java/com/freedomotic/plugins/devices/mqttclient/Mqtt.java
+++ b/plugins/devices/mqtt-client/src/main/java/com/freedomotic/plugins/devices/mqttclient/Mqtt.java
@@ -24,12 +24,12 @@ package com.freedomotic.plugins.devices.mqttclient;
  * @author Mauro Cicolella <mcicolella@libero.it>
  */
 import com.freedomotic.events.ProtocolRead;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.eclipse.paho.client.mqttv3.*;
 import org.eclipse.paho.client.mqttv3.persist.MemoryPersistence;
 
 public class Mqtt implements MqttCallback {
+    private static final Logger LOG = Logger.getLogger(Mqtt.class.getName());
 
     MqttClient4FD pluginRef = null;
     MqttClient myClient;
@@ -72,7 +72,7 @@ public class Mqtt implements MqttCallback {
             myClient.connect(connectionOptions);
             return true;
         } catch (MqttException e) {
-            MqttClient4FD.LOG.severe("Unable to connect to broker " + brokerUrl + " for " + e.getMessage());
+            LOG.severe("Unable to connect to broker " + brokerUrl + " for " + e.getMessage());
             return false;
         }
     }
@@ -81,7 +81,7 @@ public class Mqtt implements MqttCallback {
         try {
             myClient.subscribe(topic, 0);
         } catch (MqttException ex) {
-            MqttClient4FD.LOG.severe("Unable to subscribe topic + " + topic + " for reason " + ex.getLocalizedMessage());
+            LOG.severe("Unable to subscribe topic + " + topic + " for reason " + ex.getLocalizedMessage());
         }
     }
 
@@ -93,7 +93,7 @@ public class Mqtt implements MqttCallback {
         try {
             myClient.publish(topic, messageToPublish);
         } catch (MqttException ex) {
-            MqttClient4FD.LOG.severe("Unable to publish message: " + message + " to " + topic + " for " + ex.getMessage());
+            LOG.severe("Unable to publish message: " + message + " to " + topic + " for " + ex.getMessage());
         }
     }
 
@@ -101,7 +101,7 @@ public class Mqtt implements MqttCallback {
         try {
             myClient.disconnect();
         } catch (Exception e) {
-            MqttClient4FD.LOG.severe(e.getLocalizedMessage());
+            LOG.severe(e.getLocalizedMessage());
         }
     }
 
@@ -111,10 +111,10 @@ public class Mqtt implements MqttCallback {
         String address = null;
         String value = null;
 
-        System.out.println("-------------------------------------------------");
-        System.out.println("| Topic:" + topic);
-        System.out.println("| Message: " + new String(message.getPayload()));
-        System.out.println("-------------------------------------------------");
+        LOG.info("-------------------------------------------------");
+        LOG.info("| Topic:" + topic);
+        LOG.info("| Message: " + new String(message.getPayload()));
+        LOG.info("-------------------------------------------------");
         // create and notify a freedomotic event based on application logic extracting data from mqtt message
         // the event must contain some info as freedomotic object address, value
         // in this example we consider a message in the format objaddress:value
@@ -129,7 +129,7 @@ public class Mqtt implements MqttCallback {
 
     @Override
     public void deliveryComplete(IMqttDeliveryToken imdt) {
-        MqttClient4FD.LOG.info("Message published");
+        LOG.info("Message published");
     }
 
     /**
@@ -139,13 +139,13 @@ public class Mqtt implements MqttCallback {
      */
     @Override
     public void connectionLost(Throwable cause) {
-        MqttClient4FD.LOG.severe("Connection to Mqtt broker lost for " + cause.getCause());
-        MqttClient4FD.LOG.severe("Reconnecting in progress ...");
+        LOG.severe("Connection to Mqtt broker lost for " + cause.getCause());
+        LOG.severe("Reconnecting in progress ...");
         while (!myClient.isConnected()) {
             try {
                 myClient.connect(connectionOptions);
             } catch (MqttException e) {
-                MqttClient4FD.LOG.severe("Unable to connect to broker " + myClient.getServerURI() + " for " + e.getMessage());
+                LOG.severe("Unable to connect to broker " + myClient.getServerURI() + " for " + e.getMessage());
             }
             // set a delay before retrying
         }

--- a/plugins/devices/mqtt-client/src/main/java/com/freedomotic/plugins/devices/mqttclient/Mqtt.java
+++ b/plugins/devices/mqtt-client/src/main/java/com/freedomotic/plugins/devices/mqttclient/Mqtt.java
@@ -19,17 +19,23 @@
  */
 package com.freedomotic.plugins.devices.mqttclient;
 
-/**
- *
- * @author Mauro Cicolella <mcicolella@libero.it>
- */
-import com.freedomotic.events.ProtocolRead;
-import java.util.logging.Logger;
-import org.eclipse.paho.client.mqttv3.*;
+import org.eclipse.paho.client.mqttv3.IMqttDeliveryToken;
+import org.eclipse.paho.client.mqttv3.MqttCallback;
+import org.eclipse.paho.client.mqttv3.MqttClient;
+import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
+import org.eclipse.paho.client.mqttv3.MqttException;
+import org.eclipse.paho.client.mqttv3.MqttMessage;
 import org.eclipse.paho.client.mqttv3.persist.MemoryPersistence;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import com.freedomotic.events.ProtocolRead;
+
+/**
+* @author Mauro Cicolella <mcicolella@libero.it>
+*/
 public class Mqtt implements MqttCallback {
-    private static final Logger LOG = Logger.getLogger(Mqtt.class.getName());
+    private static final Logger LOG = LoggerFactory.getLogger(Mqtt.class.getName());
 
     MqttClient4FD pluginRef = null;
     MqttClient myClient;
@@ -72,7 +78,7 @@ public class Mqtt implements MqttCallback {
             myClient.connect(connectionOptions);
             return true;
         } catch (MqttException e) {
-            LOG.severe("Unable to connect to broker " + brokerUrl + " for " + e.getMessage());
+            LOG.error("Unable to connect to broker " + brokerUrl + " for " + e.getMessage());
             return false;
         }
     }
@@ -81,7 +87,7 @@ public class Mqtt implements MqttCallback {
         try {
             myClient.subscribe(topic, 0);
         } catch (MqttException ex) {
-            LOG.severe("Unable to subscribe topic + " + topic + " for reason " + ex.getLocalizedMessage());
+            LOG.error("Unable to subscribe topic + " + topic + " for reason " + ex.getLocalizedMessage());
         }
     }
 
@@ -93,7 +99,7 @@ public class Mqtt implements MqttCallback {
         try {
             myClient.publish(topic, messageToPublish);
         } catch (MqttException ex) {
-            LOG.severe("Unable to publish message: " + message + " to " + topic + " for " + ex.getMessage());
+            LOG.error("Unable to publish message: " + message + " to " + topic + " for " + ex.getMessage());
         }
     }
 
@@ -101,7 +107,7 @@ public class Mqtt implements MqttCallback {
         try {
             myClient.disconnect();
         } catch (Exception e) {
-            LOG.severe(e.getLocalizedMessage());
+            LOG.error(e.getLocalizedMessage());
         }
     }
 
@@ -139,13 +145,13 @@ public class Mqtt implements MqttCallback {
      */
     @Override
     public void connectionLost(Throwable cause) {
-        LOG.severe("Connection to Mqtt broker lost for " + cause.getCause());
-        LOG.severe("Reconnecting in progress ...");
+        LOG.error("Connection to Mqtt broker lost for " + cause.getCause());
+        LOG.error("Reconnecting in progress ...");
         while (!myClient.isConnected()) {
             try {
                 myClient.connect(connectionOptions);
             } catch (MqttException e) {
-                LOG.severe("Unable to connect to broker " + myClient.getServerURI() + " for " + e.getMessage());
+                LOG.error("Unable to connect to broker " + myClient.getServerURI() + " for " + e.getMessage());
             }
             // set a delay before retrying
         }

--- a/plugins/devices/mqtt-client/src/main/java/com/freedomotic/plugins/devices/mqttclient/MqttClient4FD.java
+++ b/plugins/devices/mqtt-client/src/main/java/com/freedomotic/plugins/devices/mqttclient/MqttClient4FD.java
@@ -22,16 +22,18 @@
  */
 package com.freedomotic.plugins.devices.mqttclient;
 
+import java.io.IOException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.freedomotic.api.EventTemplate;
 import com.freedomotic.api.Protocol;
-import com.freedomotic.app.Freedomotic;
 import com.freedomotic.exceptions.UnableToExecuteException;
 import com.freedomotic.reactions.Command;
-import java.io.IOException;
-import java.util.logging.Logger;
 
 public class MqttClient4FD extends Protocol {
-    private static final Logger LOG = Logger.getLogger(MqttClient4FD.class.getName());
+    private static final Logger LOG = LoggerFactory.getLogger(MqttClient4FD.class.getName());
 
     private String BROKER_URL = configuration.getStringProperty("broker-url", "tcp://test.mosquitto.org:1883");
     private String CLIENT_ID = configuration.getStringProperty("client-id", "freedomotic");

--- a/plugins/devices/mqtt-client/src/main/java/com/freedomotic/plugins/devices/mqttclient/MqttClient4FD.java
+++ b/plugins/devices/mqtt-client/src/main/java/com/freedomotic/plugins/devices/mqttclient/MqttClient4FD.java
@@ -30,10 +30,9 @@ import com.freedomotic.reactions.Command;
 import java.io.IOException;
 import java.util.logging.Logger;
 
-public class MqttClient4FD
-        extends Protocol {
+public class MqttClient4FD extends Protocol {
+    private static final Logger LOG = Logger.getLogger(MqttClient4FD.class.getName());
 
-    public static final Logger LOG = Logger.getLogger(MqttClient4FD.class.getName());
     private String BROKER_URL = configuration.getStringProperty("broker-url", "tcp://test.mosquitto.org:1883");
     private String CLIENT_ID = configuration.getStringProperty("client-id", "freedomotic");
     private String AUTHENTICATION_ENABLED = configuration.getStringProperty("authentication-enabled", "false");


### PR DESCRIPTION
Replaced all System.out.println(...) calls with LOG.info(...) calls. Also
made the logger of MqttClient4FD private in order to make sure that
messages in the log come from the correct class. Otherwise debugging will
be harder as problems in Mqtt will be logged from MqttCleint4FD and
developers would start to search in that class.

This pull request contributes to issue #209.