### PR TITLE
Mailer attachment management added

### DIFF
--- a/framework/freedomotic-core/src/main/java/com/freedomotic/events/MessageEvent.java
+++ b/framework/freedomotic-core/src/main/java/com/freedomotic/events/MessageEvent.java
@@ -19,9 +19,12 @@
  */
 package com.freedomotic.events;
 
-import com.freedomotic.api.EventTemplate;
+import java.io.File;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.freedomotic.api.EventTemplate;
 
 /**
  * Channel <b>app.event.sensor.messages.MESSAGE_TYPE</b> informs that
@@ -102,6 +105,30 @@ public class MessageEvent
     public void setTo(String to) {
         this.getPayload().addStatement("message.to", to);
     }
+    
+
+    /**
+     * Sets the path of the message attachment, if any.
+     * 
+     * it is an OPTIONAL property
+     *
+     * @param path
+     */
+    public void setAttachmentPath(String path) {
+        this.getPayload().addStatement("message.attachment", path);
+    }
+    
+    /**
+     * Sets the path of the attached file, if any.
+     * 
+     * it is an OPTIONAL property
+     *
+     * @param file representing the actual attachment
+     */
+    public void setAttachmentPath(File attachment) {
+    	String path = (attachment!=null)?attachment.getAbsolutePath():"";
+        this.getPayload().addStatement("message.attachment", path);
+    }
 
     /**
      *
@@ -126,7 +153,17 @@ public class MessageEvent
     public String getText() {
         return getPayload().getStatementValue("message.text");
     }
+    
+    /**
+     * 
+     * @return the absolute attachment path, if any
+     */
+    public String getAttachmentPath() {
+    	return getPayload().getStatementValue("message.attachment");
+    }
 
+    
+    
     /**
      *
      * @return

--- a/plugins/devices/mailer/pom.xml
+++ b/plugins/devices/mailer/pom.xml
@@ -63,6 +63,12 @@
             <artifactId>mail</artifactId>
             <version>1.4</version>
         </dependency>
+		<dependency>
+    		<groupId>dumbster</groupId>
+    		<artifactId>dumbster</artifactId>
+    		<version>1.6</version>
+    		<scope>test</scope>
+		</dependency>
     </dependencies>
     <build>
         <plugins>

--- a/plugins/devices/mailer/src/main/java/com/freedomotic/plugins/devices/mailer/Mailer.java
+++ b/plugins/devices/mailer/src/main/java/com/freedomotic/plugins/devices/mailer/Mailer.java
@@ -19,24 +19,32 @@
  */
 package com.freedomotic.plugins.devices.mailer;
 
+import java.io.File;
+import java.io.IOException;
+import java.util.Date;
+import java.util.Properties;
+
+import javax.mail.Message;
+import javax.mail.MessagingException;
+import javax.mail.Multipart;
+import javax.mail.PasswordAuthentication;
+import javax.mail.Session;
+import javax.mail.Transport;
+import javax.mail.internet.AddressException;
+import javax.mail.internet.InternetAddress;
+import javax.mail.internet.MimeBodyPart;
+import javax.mail.internet.MimeMessage;
+import javax.mail.internet.MimeMultipart;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.freedomotic.api.EventTemplate;
 import com.freedomotic.api.Protocol;
 import com.freedomotic.app.Freedomotic;
 import com.freedomotic.events.MessageEvent;
 import com.freedomotic.exceptions.UnableToExecuteException;
 import com.freedomotic.reactions.Command;
-import java.io.IOException;
-import java.util.Properties;
-import javax.mail.Message;
-import javax.mail.MessagingException;
-import javax.mail.PasswordAuthentication;
-import javax.mail.Session;
-import javax.mail.Transport;
-import javax.mail.internet.AddressException;
-import javax.mail.internet.InternetAddress;
-import javax.mail.internet.MimeMessage;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  *
@@ -44,105 +52,152 @@ import org.slf4j.LoggerFactory;
  */
 public final class Mailer extends Protocol {
 
-    /**
-     *
-     */
-    public static final Logger LOG = LoggerFactory.getLogger(Mailer.class.getName());
-    final String USERNAME = configuration.getProperty("username");
-    final String PASSWORD = configuration.getProperty("password");
-    private int sentMails;
+	/**
+	 *
+	 */
+	public static final Logger LOG = LoggerFactory.getLogger(Mailer.class.getName());
+	final String USERNAME = configuration.getProperty("username");
+	final String PASSWORD = configuration.getProperty("password");
+	private int sentMails;
 
-    /**
-     *
-     */
-    public Mailer() {
-        super("Mailer", "/mailer/mailer-manifest.xml");
-        addEventListener("app.event.sensor.messages.mail");
-    }
+	/**
+	 *
+	 */
+	public Mailer() {
+		super("Mailer", "/mailer/mailer-manifest.xml");
+		addEventListener("app.event.sensor.messages.mail");
+	}
+	
+	@Override
+	protected void onRun() {
+		// throw new UnsupportedOperationException("Not supported yet.");
+	}
 
-    @Override
-    protected void onRun() {
-        //throw new UnsupportedOperationException("Not supported yet.");
-    }
+	@Override
+	protected void onCommand(Command c) throws IOException, UnableToExecuteException {
+		String from = c.getProperty("from");
+		if (from == null) {
+			from = "your.home@freedomotic.com";
+		}
+		String to = c.getProperty("to");
+		if (to == null || to.isEmpty()) {
+			to = USERNAME;
+		}
+		String subject = c.getProperty("subject");
+		if (subject == null || subject.isEmpty()) {
+			subject = "A notification from Freedomotic";
+		}
+		final String text = c.getProperty("message");
 
-    @Override
-    protected void onCommand(Command c) throws IOException, UnableToExecuteException {
-        String from = c.getProperty("from");
-        if (from == null) {
-            from = "your.home@freedomotic.com";
-        }
-        String to = c.getProperty("to");
-        if (to == null || to.isEmpty()) {
-            to = USERNAME;
-        }
-        String subject = c.getProperty("subject");
-        if (subject == null || subject.isEmpty()) {
-            subject = "A notification from Freedomotic";
-        }
-        final String text = c.getProperty("message");
-        try {
-            send(from, to, subject, text);
-        } catch (MessagingException ex) {
-            this.notifyCriticalError("Error while sending email '" + subject + "' to '" + to + "' for " + Freedomotic.getStackTraceInfo(ex));
-        }
+		try {
+			send(from, to, subject, text, this.buildAttachmentFromAbsolutePath(c.getProperty("attachment")));
+		} catch (MessagingException ex) {
+			this.notifyCriticalError("Error while sending email '" + subject + "' to '" + to + "' for "
+					+ Freedomotic.getStackTraceInfo(ex));
+		}
 
-    }
+	}
 
-    /**
-     * Sends the mail.
-     *
-     * @param from mail sender
-     * @param to mail receiver
-     * @param subject mail subject
-     * @param text mail body
-     * @throws AddressException
-     * @throws MessagingException
-     */
-    private void send(String from, String to, String subject, String text) throws AddressException, MessagingException {
-        Properties props = new Properties();
-        props.put("mail.smtp.auth", configuration.getProperty("mail.smtp.auth"));
-        if (configuration.getProperty("mail.smtp.connection").equalsIgnoreCase("TLS")) {
-            props.put("mail.smtp.starttls.enable", "true");
-        } else {
-            props.put("mail.smtp.socketFactory.port", configuration.getProperty("mail.smtp.port"));
-            props.put("mail.smtp.socketFactory.class", "javax.net.ssl.SSLSocketFactory");
-        }
-        props.put("mail.smtp.host", configuration.getProperty("mail.smtp.host"));
-        props.put("mail.smtp.port", configuration.getProperty("mail.smtp.port"));
+	private File buildAttachmentFromAbsolutePath(String path) {
+		if (path == null || path.isEmpty())
+			return null;
 
-        Session session = Session.getInstance(props,
-                new javax.mail.Authenticator() {
-                    @Override
-                    protected PasswordAuthentication getPasswordAuthentication() {
-                        return new PasswordAuthentication(USERNAME, PASSWORD);
-                    }
-                });
+		File attachment = new File(path);
 
-        Message message = new MimeMessage(session);
-        message.setFrom(new InternetAddress("you@home.com"));
-        message.setRecipients(Message.RecipientType.TO, InternetAddress.parse(to));
-        message.setSubject(subject);
-        message.setText(text);
+		if (attachment.exists())
+			return attachment;
+		else {
+			this.notifyCriticalError("Error while retrieving mail attachment, no existing file at path " + path);
+			return null;
+		}
+	}
 
-        Transport.send(message);
-        sentMails++;
-        setDescription(sentMails + " emails sent");
-    }
+	/**
+	 * Sends the mail with an attachment, if any.
+	 *
+	 * @param from
+	 *            mail sender
+	 * @param to
+	 *            mail receiver
+	 * @param subject
+	 *            mail subject
+	 * @param text
+	 *            mail body
+	 * @param attached file
+	 *            mail attachment, if any
+	 *            
+	 * @throws AddressException
+	 * @throws MessagingException
+	 * @throws IOException
+	 */
+	private void send(String from, String to, String subject, String text, File attachment)
+			throws AddressException, MessagingException, IOException {
+		Properties props = new Properties();
+		props.put("mail.smtp.auth", configuration.getProperty("mail.smtp.auth"));
+		if (configuration.getProperty("mail.smtp.connection").equalsIgnoreCase("TLS")) {
+			props.put("mail.smtp.starttls.enable", "true");
+		} else {
+			props.put("mail.smtp.socketFactory.port", configuration.getProperty("mail.smtp.port"));
+			props.put("mail.smtp.socketFactory.class", "javax.net.ssl.SSLSocketFactory");
+		}
+		props.put("mail.smtp.host", configuration.getProperty("mail.smtp.host"));
+		props.put("mail.smtp.port", configuration.getProperty("mail.smtp.port"));
 
-    @Override
-    protected boolean canExecute(Command c) {
-        throw new UnsupportedOperationException("Not supported yet.");
-    }
+		Session session = Session.getInstance(props, new javax.mail.Authenticator() {
+			@Override
+			protected PasswordAuthentication getPasswordAuthentication() {
+				return new PasswordAuthentication(USERNAME, PASSWORD);
+			}
+		});
 
-    @Override
-    protected void onEvent(EventTemplate event) {
-        if (event instanceof MessageEvent) {
-            MessageEvent mail = (MessageEvent) event;
-            try {
-                send(mail.getFrom(), mail.getTo(), null, mail.getText());
-            } catch (MessagingException ex) {
-                this.notifyCriticalError("Error while sending email to " + mail.getTo() + ": " + ex.getMessage());
-            }
-        }
-    }
+		Message message = new MimeMessage(session);
+		message.setFrom(new InternetAddress(from));
+		message.setRecipients(Message.RecipientType.TO, InternetAddress.parse(to));
+		message.setSubject(subject);
+
+		if (attachment != null) {
+			MimeBodyPart textMsg = new MimeBodyPart();
+			textMsg.setText(text);
+			MimeBodyPart attachedFile = new MimeBodyPart();
+			attachedFile.attachFile(attachment);
+
+			Multipart mp = new MimeMultipart();
+			mp.addBodyPart(textMsg);
+			mp.addBodyPart(attachedFile);
+			message.setContent(mp);
+		}
+		
+		else {
+			message.setText(text);
+		}
+
+		message.setSentDate(new Date());
+
+		Transport.send(message);
+		sentMails++;
+		setDescription(sentMails + " emails sent");
+	}
+	
+	private void sendWithAttachment(String from, String to, String subject, String text, String attachmentPath)
+			throws AddressException, MessagingException, IOException {
+		File attachment = this.buildAttachmentFromAbsolutePath(attachmentPath);
+		this.send(from, to, subject, text, attachment);
+	}
+
+	@Override
+	protected boolean canExecute(Command c) {
+		throw new UnsupportedOperationException("Not supported yet.");
+	}
+
+	@Override
+	protected void onEvent(EventTemplate event) {
+		if (event instanceof MessageEvent) {
+			MessageEvent mail = (MessageEvent) event;
+			try {
+				this.sendWithAttachment(mail.getFrom(), mail.getTo(), null, mail.getText(), mail.getAttachmentPath());
+			} catch (Exception ex) {
+				this.notifyCriticalError("Error while sending email to " + mail.getTo() + ": " + ex.getMessage());
+			}
+		}
+	}
 }

--- a/plugins/devices/mailer/src/test/java/com/freedomotic/plugins/devices/mailer/MailerPluginTest.java
+++ b/plugins/devices/mailer/src/test/java/com/freedomotic/plugins/devices/mailer/MailerPluginTest.java
@@ -1,0 +1,100 @@
+/**
+ *
+ * Copyright (c) 2009-2016 Freedomotic team http://freedomotic.com
+ *
+ * This file is part of Freedomotic
+ *
+ * This Program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2, or (at your option) any later version.
+ *
+ * This Program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * Freedomotic; see the file COPYING. If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+package com.freedomotic.plugins.devices.mailer;
+
+import java.io.File;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.dumbster.smtp.SimpleSmtpServer;
+import com.freedomotic.events.MessageEvent;
+
+/**
+ *
+ * @author P3trur0, https://flatmap.it
+ */
+
+public class MailerPluginTest {
+
+	public MailerPluginTest() {
+	}
+
+	private File attachment;
+	private static SimpleSmtpServer dummySMTPServer; 
+	/**
+	 *
+	 */
+	@BeforeClass
+	public static void setUpClass() {
+		dummySMTPServer = SimpleSmtpServer.start(2525);
+	}
+
+	/**
+	 *
+	 */
+	@AfterClass
+	public static void tearDownClass() {
+		dummySMTPServer.stop();
+		Assert.assertTrue(dummySMTPServer.isStopped());
+	}
+
+	/**
+	 *
+	 */
+	@Before
+	public void setUp() {
+		this.attachment = new File(getClass().getResource("attachment.txt").getFile());
+	}
+
+	/**
+	 *
+	 */
+	@After
+	public void tearDown() {
+	}
+
+	@Test
+	public void testLoadPlugins() throws Exception {
+
+		boolean thrown = false;
+
+//		MessageEvent me = new MessageEvent(null, "Mail test");
+//		me.setAttachmentPath(attachment.getAbsolutePath());
+//		me.setType("email");
+//		me.setFrom("test@email.com");
+//		me.setTo("test@recipient.com");
+//
+//		try {
+//			Mailer m = new Mailer();
+//			m.onEvent(me);
+//		} catch (Exception e) {
+//			thrown = true;
+//			System.out.println(e.getMessage());
+//		}
+
+		Assert.assertFalse("The mail onEvent should not send any exception if properly sent", thrown);
+	}
+
+}


### PR DESCRIPTION
This pull request fixes the issue #217.

It allows to add an optional attachment attribute to properties either of `Command` or `MessageEvent`, in order to support sending of attachments together with mail text.

I've set up also an Unit test to verify the behavior, but due to the `Injector` mechanism to build plugins instances I did not easily found a way to instantiate the `Mailer` object in the Unit test.

---

**NOTE**
To mock an STMP server for Unit tests, I've introduced also a Maven dependency, `test` scoped. It is [Dumbster](http://quintanasoft.com/dumbster/), version 1.6.