### PR TITLE
added a mechanism to load backrounds from different disk paths

### DIFF
--- a/framework/freedomotic-core/src/main/java/com/freedomotic/core/ResourcesManager.java
+++ b/framework/freedomotic-core/src/main/java/com/freedomotic/core/ResourcesManager.java
@@ -35,6 +35,8 @@ import java.io.File;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import javax.imageio.ImageIO;
@@ -86,8 +88,18 @@ public final class ResourcesManager {
                 //get the unresized image from cache or disk
                 try {
                     img = imagesCache.get(imageName);
-                } catch (Exception e) {
-                    return null;
+                } catch (ExecutionException e) {
+                    try {
+                    	File imageFile = new File(imageName);
+                    	if(imageFile.exists()) {
+                    		img = ImageIO.read(imageFile);
+                    		imagesCache.put(imageFile.getName(), img);
+                    	}
+                    	else
+                    		return null;
+                    } catch(IOException er) {
+                    	return null;
+                    }
                 }
                 // Resize and cache
                 if (img.getWidth() != width && img.getHeight() != height) {
@@ -101,7 +113,7 @@ public final class ResourcesManager {
             return null;
         }
     }
-
+    
     /**
      *
      * @param imageName

--- a/plugins/devices/frontend-java/src/main/java/com/freedomotic/jfrontend/MainWindow.java
+++ b/plugins/devices/frontend-java/src/main/java/com/freedomotic/jfrontend/MainWindow.java
@@ -53,6 +53,8 @@ import javax.swing.UIManager;
 import javax.swing.UnsupportedLookAndFeelException;
 import javax.swing.WindowConstants;
 
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.FilenameUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -1114,7 +1116,7 @@ private void jCheckBoxMarketActionPerformed(java.awt.event.ActionEvent evt) {//G
 
     private void mnuBackgroundActionPerformed(java.awt.event.ActionEvent evt)    {//GEN-FIRST:event_mnuBackgroundActionPerformed
 
-        final JFileChooser fc = new JFileChooser(Info.PATHS.PATH_DATA_FOLDER + "/resources/");
+        final JFileChooser fc = new JFileChooser(Info.PATHS.PATH_DATA_FOLDER + File.separator + "resources"+ File.separator+"system"+File.separator+"map"+File.separator);
         OpenDialogFileFilter filter = new OpenDialogFileFilter();
         filter.addExtension("png");
         filter.addExtension("jpeg");
@@ -1129,12 +1131,28 @@ private void jCheckBoxMarketActionPerformed(java.awt.event.ActionEvent evt) {//G
             File file = fc.getSelectedFile();
             //This is where a real application would open the file.
             LOG.info("Opening {}", file.getAbsolutePath());
-            drawer.getCurrEnv().getPojo().setBackgroundImage(file.getName());
+            file = this.moveBackgroundFile(file);
+            drawer.getCurrEnv().getPojo().setBackgroundImage(file.getAbsolutePath());
             drawer.setNeedRepaint(true);
             frameMap.validate();
         }
     }//GEN-LAST:event_mnuBackgroundActionPerformed
 
+    private File moveBackgroundFile(File backgroundImage) {
+    	File resourcesFolder = new File(Info.PATHS.PATH_DATA_FOLDER + File.separator + "resources"+ File.separator+"system"+File.separator+"map");
+    
+    	if(backgroundImage.exists() && resourcesFolder.isDirectory() && !(new File(resourcesFolder, backgroundImage.getName()).exists())) {
+    		try {
+				FileUtils.copyFileToDirectory(backgroundImage, resourcesFolder);
+				backgroundImage = new File(resourcesFolder,backgroundImage.getName());
+			} catch (IOException e) {
+				 LOG.error(e.getMessage(),e);
+			}
+    	}
+    	
+    	return backgroundImage;
+    }
+    
     private void mnuRoomBackgroundActionPerformed(java.awt.event.ActionEvent evt)    {//GEN-FIRST:event_mnuRoomBackgroundActionPerformed
 
         ZoneLogic zone = drawer.getSelectedZone();


### PR DESCRIPTION
@mcicolella eventually, I chose another approach than the one proposed in my first comment for issue #117: I've modified the resource locator for background images such to support loadings of file images located also in disk path different from `resources`.

Basically, when a file reference is forwarded to the locator, it checks if the resource exists in the current Freedomotic cache, if not (but the file does exist on the current disk) the resource locator updates the cache with the file and set it as the selected backround.

Please let me know if this approach is suitable for you.

If so, I'd be glad to have this PR merged.

Good evening!

@P3trur0