### PR TITLE
added 'type' property to both event and commands

### DIFF
--- a/framework/freedomotic-core/src/main/java/com/freedomotic/api/EventTemplate.java
+++ b/framework/freedomotic-core/src/main/java/com/freedomotic/api/EventTemplate.java
@@ -46,6 +46,8 @@ public class EventTemplate implements Serializable {
     protected boolean isValid;
     private long creation;
     private final String uuid = UUID.randomUUID().toString();
+    private final String type = "event";
+    
 
     @XStreamOmitField
     private static final Logger LOG = LoggerFactory.getLogger(EventTemplate.class.getName());
@@ -165,6 +167,7 @@ public class EventTemplate implements Serializable {
             payload.addStatement("sender",
                     getSender());
             payload.addStatement("uuid", this.uuid);
+            payload.addStatement("type", this.type);
         } catch (Exception e) {
             LOG.error("Error while generating default data for event", e);
         }

--- a/framework/freedomotic-core/src/main/java/com/freedomotic/api/EventTemplate.java
+++ b/framework/freedomotic-core/src/main/java/com/freedomotic/api/EventTemplate.java
@@ -48,8 +48,7 @@ public class EventTemplate implements Serializable {
     private final String uuid = UUID.randomUUID().toString();
     private final String type = "event";
     
-
-    @XStreamOmitField
+	@XStreamOmitField
     private static final Logger LOG = LoggerFactory.getLogger(EventTemplate.class.getName());
 
     protected void generateEventPayload() {
@@ -217,5 +216,11 @@ public class EventTemplate implements Serializable {
 		return this.uuid;
 	}
     
+	/**
+	 * @return the type of this class
+	 */
+	public String getType() {
+		return type;
+	}
     
 }

--- a/framework/freedomotic-core/src/main/java/com/freedomotic/reactions/Command.java
+++ b/framework/freedomotic-core/src/main/java/com/freedomotic/reactions/Command.java
@@ -87,7 +87,7 @@ public final class Command implements Serializable, Cloneable {
     private boolean executed;
     @XmlElement(name = "props")
     private Config properties = new Config();
-    private final String type = this.getClass().getSimpleName().toLowerCase();
+    private final String type = "command";
 
     /**
      *

--- a/framework/freedomotic-core/src/main/java/com/freedomotic/reactions/Command.java
+++ b/framework/freedomotic-core/src/main/java/com/freedomotic/reactions/Command.java
@@ -87,12 +87,14 @@ public final class Command implements Serializable, Cloneable {
     private boolean executed;
     @XmlElement(name = "props")
     private Config properties = new Config();
+    private final String type = this.getClass().getSimpleName().toLowerCase();
 
     /**
      *
      */
     public Command() {
         this.uuid = UUID.randomUUID().toString();
+        this.properties.setProperty("type", type);
         if (isHardwareLevel()) { //an hardware level command
             setEditable(false); //it has not to be stored in root/data folder
         }
@@ -510,4 +512,11 @@ public final class Command implements Serializable, Cloneable {
     public void setReplyTimeout(int timeout) {
         this.timeout = timeout;
     }
+
+	/**
+	 * @return the type
+	 */
+	public String getType() {
+		return type;
+	}
 }


### PR DESCRIPTION
This solves #247 by adding two generic properties both on Command and EventTemplates to determine if the payload belongs to command or events.

- Command property will be `type=command`
- Event property will be `event.type=event`