### PR TITLE
issue 259 fixed

### DIFF
--- a/plugins/devices/frontend-java/src/main/java/com/freedomotic/jfrontend/MainWindow.java
+++ b/plugins/devices/frontend-java/src/main/java/com/freedomotic/jfrontend/MainWindow.java
@@ -30,6 +30,7 @@ import java.awt.KeyboardFocusManager;
 import java.awt.Rectangle;
 import java.awt.Toolkit;
 import java.awt.event.KeyEvent;
+import java.awt.event.WindowEvent;
 import java.beans.PropertyVetoException;
 import java.io.File;
 import java.io.IOException;
@@ -54,7 +55,6 @@ import javax.swing.UnsupportedLookAndFeelException;
 import javax.swing.WindowConstants;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.FilenameUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -580,6 +580,10 @@ public class MainWindow
             }
             public void windowClosed(java.awt.event.WindowEvent evt) {
                 formWindowClosed(evt);
+            }
+            
+            public void windowActivated(java.awt.event.WindowEvent evt) {
+            	drawer.repaint();
             }
         });
         addComponentListener(new java.awt.event.ComponentAdapter() {


### PR DESCRIPTION
This should solve #259.

This PR introduces a new `eventListener` on window state change events. When this event type occurs, a `drawer.repaint()` is invoked to refresh all the GUI data properly.

Please, let me know if this fixes the problem.