### PR TITLE
Missing Jackson Databind dependency added. Jackson Annotations dependency bumped

### DIFF
--- a/framework/freedomotic-model/pom.xml
+++ b/framework/freedomotic-model/pom.xml
@@ -38,8 +38,13 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.6.2</version>
+            <version>2.8.9</version>
             <type>jar</type>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.8.9</version>
         </dependency>
     </dependencies>
     <build>

--- a/plugins/devices/restapi-v3/pom.xml
+++ b/plugins/devices/restapi-v3/pom.xml
@@ -80,6 +80,12 @@
             <artifactId>jersey-media-json-jackson</artifactId>
             <version>${jersey.version}</version>
         </dependency>
+         <!-- Jersey guava support to repackaged Guava classes-->
+        <dependency>
+   	 		<groupId>org.glassfish.jersey.bundles.repackaged</groupId>
+    		<artifactId>jersey-guava</artifactId>
+    		<version>${jersey.version}</version>
+		</dependency>
         <dependency>
             <groupId>com.wordnik</groupId>
             <artifactId>swagger-jaxrs_2.11</artifactId>


### PR DESCRIPTION
Hi there!

I see that this error happens because of the Jackson Databind dependency missing.

Also, I take the opportunity to bump the Jackson Annotations dependency to the **2.8.9** version.

Please see if this solves the issue.

Have a nice evening,

@P3trur0