### PR TITLE
Reduced image layers.

### DIFF
--- a/scripts/docker/alpine/Dockerfile
+++ b/scripts/docker/alpine/Dockerfile
@@ -1,17 +1,18 @@
 FROM openjdk:8-jre-alpine
+LABEL freedomotic.version="5.6.0"
+MAINTAINER Matteo Mazzoni <matteo@freedomotic.com>
 
-MAINTAINER Matteo Mazzoni <matteo@freedomotic.com> 
+ENV FREEDOMOTIC_URL="http://teamcity.jetbrains.com/guestAuth/repository/download/bt1177/.lastSuccessful/freedomotic-5.6.0-%7Bbuild.number%7D.zip"
 
-RUN apk add --no-cache wget
+RUN apk add --no-cache wget \
+    && wget "${FREEDOMOTIC_URL}" -O latest.zip \
+    && apk del wget \
+    && unzip latest.zip -d /srv/ \
+    && rm latest.zip \
+    && mv /srv/freedom* /srv/freedomotic \
+    && rm -rf /srv/freedomotic/plugins/devices/frontend-java
 
-RUN wget "http://teamcity.jetbrains.com/guestAuth/repository/download/bt1177/.lastSuccessful/freedomotic-5.6.0-%7Bbuild.number%7D.zip" -O latest.zip
-RUN unzip latest.zip -d /srv/
-RUN rm latest.zip
-RUN mv /srv/freedom* /srv/freedomotic
-RUN rm -rf /srv/freedomotic/plugins/devices/frontend-java
-
-VOLUME /srv/freedomotic/data
-VOLUME /srv/freedomotic/plugins
+VOLUME /srv/freedomotic/data /srv/freedomotic/plugins
 
 EXPOSE 9111 8090
 

--- a/scripts/docker/amd64/Dockerfile
+++ b/scripts/docker/amd64/Dockerfile
@@ -1,18 +1,18 @@
-FROM java:8-jre 
-
+FROM openjdk:8-jre
+LABEL freedomotic.version="5.6.0"
 MAINTAINER Matteo Mazzoni <matteo@freedomotic.com> 
 
-RUN apt-get update && apt-get upgrade -y
+ENV FREEDOMOTIC_URL="http://teamcity.jetbrains.com/guestAuth/repository/download/bt1177/.lastSuccessful/freedomotic-5.6.0-%7Bbuild.number%7D.zip"
 
-# RUN wget "http://teamcity.codebetter.com/guestAuth/repository/download/bt1177/.lastSuccessful/freedomotic-5.6.0-%7Bbuild.number%7D.zip" -O latest.zip
-RUN wget "http://teamcity.jetbrains.com/guestAuth/repository/download/bt1177/.lastSuccessful/freedomotic-5.6.0-%7Bbuild.number%7D.zip" -O latest.zip
-RUN unzip latest.zip -d /srv/
-RUN rm latest.zip
-RUN mv /srv/freedom* /srv/freedomotic
-RUN rm -rf /srv/freedomotic/plugins/devices/frontend-java
+RUN apt-get update \
+    && wget "${FREEDOMOTIC_URL}" -O latest.zip \
+    && unzip latest.zip -d /srv/ \
+    && rm latest.zip \
+    && mv /srv/freedom* /srv/freedomotic \
+    && rm -rf /srv/freedomotic/plugins/devices/frontend-java \
+    && rm -rf /var/lib/apt/lists/*
 
-VOLUME /srv/freedomotic/data
-VOLUME /srv/freedomotic/plugins
+VOLUME /srv/freedomotic/data /srv/freedomotic/plugins
 
 EXPOSE 9111 8090
 


### PR DESCRIPTION
- Reduced image layers using [best practices](https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#run).

- Changed base image in amd64

Resulted in a build of `131MB` for the alpine based image.