### PR TITLE
#452 Change the swagger version to the last version available

### DIFF
--- a/plugins/devices/restapi-v3/pom.xml
+++ b/plugins/devices/restapi-v3/pom.xml
@@ -147,7 +147,7 @@
             <plugin>
                 <groupId>com.github.kongchen</groupId>
                 <artifactId>swagger-maven-plugin</artifactId>
-                <version>2.2</version>
+                <version>3.1.7</version>
                 <configuration>
                     <apiSources>
                         <apiSource>


### PR DESCRIPTION
Change the swagger version. 

2.2 -> 3.1.7 

Reference: https://mvnrepository.com/artifact/com.github.kongchen/swagger-maven-plugin/3.1.7