### PR TITLE
Twilight plugin: switch from Joda to Java 8 time

### DIFF
--- a/plugins/devices/twilight/pom.xml
+++ b/plugins/devices/twilight/pom.xml
@@ -59,11 +59,6 @@
             <version>${project.parent.version}</version>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
-            <version>2.9.9</version>
-        </dependency>
     </dependencies>
 
      <build>

--- a/plugins/devices/twilight/src/main/java/com/freedomotic/plugins/devices/twilight/Twilight.java
+++ b/plugins/devices/twilight/src/main/java/com/freedomotic/plugins/devices/twilight/Twilight.java
@@ -27,7 +27,7 @@ import com.freedomotic.reactions.Command;
 import com.freedomotic.plugins.devices.twilight.providers.EarthToolsWI;
 import com.freedomotic.plugins.devices.twilight.providers.OpenWeatherMapWI;
 import java.io.IOException;
-import org.joda.time.DateTime;
+import java.time.ZonedDateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -81,7 +81,7 @@ public class Twilight extends Protocol {
 
     @Override
     protected void onRun() {
-        EventTemplate ev = TLU.prepareEvent(DateTime.now());
+        EventTemplate ev = TLU.prepareEvent(ZonedDateTime.now());
         LOG.info(ev.getPayload().toString().replace("\n", " "));
         notifyEvent(ev);
 

--- a/plugins/devices/twilight/src/main/java/com/freedomotic/plugins/devices/twilight/TwilightUtils.java
+++ b/plugins/devices/twilight/src/main/java/com/freedomotic/plugins/devices/twilight/TwilightUtils.java
@@ -20,8 +20,8 @@
 package com.freedomotic.plugins.devices.twilight;
 
 import com.freedomotic.events.GenericEvent;
-import org.joda.time.DateTime;
-import org.joda.time.Duration;
+import java.time.Duration;
+import java.time.ZonedDateTime;
 
 /**
  *
@@ -47,9 +47,9 @@ public class TwilightUtils {
      * @param ref
      * @return
      */
-    public GenericEvent prepareEvent(DateTime ref) {
-        DateTime sunsetTime = provider.getNextSunset();
-        DateTime sunriseTime = provider.getNextSunrise();
+    public GenericEvent prepareEvent(ZonedDateTime ref) {
+        ZonedDateTime sunsetTime = provider.getNextSunset();
+        ZonedDateTime sunriseTime = provider.getNextSunrise();
 
         while (sunsetTime.isBefore(ref) && sunriseTime.isBefore(ref)) {
             if (sunsetTime.isBefore(sunriseTime)) {
@@ -61,33 +61,33 @@ public class TwilightUtils {
             }
         }
 
-        Duration toSunset = sunsetTime.isAfter(ref) ? new Duration(ref, sunsetTime) : new Duration(sunsetTime, ref);
-        Duration toSunrise = sunriseTime.isAfter(ref) ? new Duration(ref, sunriseTime) : new Duration(sunriseTime, ref);
+        Duration toSunset = sunsetTime.isAfter(ref) ? Duration.between(ref, sunsetTime) : Duration.between(sunsetTime, ref);
+        Duration toSunrise = sunriseTime.isAfter(ref) ? Duration.between(ref, sunriseTime) : Duration.between(sunriseTime, ref);
 
         // create the event 
         GenericEvent ev = new GenericEvent(getClass());
         ev.setDestination("app.event.sensor.calendar.event.twilight");
 
-        if (toSunset.getMillis() < POLLING_WAIT / 2) {
+        if (toSunset.toMillis() < POLLING_WAIT / 2) {
             // it's sunset
             ev.addProperty("isSunset", "true");
-        } else if (toSunrise.getMillis() < POLLING_WAIT / 2) {
+        } else if (toSunrise.toMillis() < POLLING_WAIT / 2) {
             // it's sunrise
             ev.addProperty("isSunrise", "true");
         }
         if (ref.isBefore(sunriseTime)) {
             // before sunrise
-            ev.addProperty("beforeSunrise", Long.toString(toSunrise.getStandardMinutes()));
+            ev.addProperty("beforeSunrise", Long.toString(toSunrise.toMinutes()));
         } else if (ref.isAfter(sunriseTime)) {
             // after sunrise 
-            ev.addProperty("afterSunrise", Long.toString(toSunrise.getStandardMinutes()));
+            ev.addProperty("afterSunrise", Long.toString(toSunrise.toMinutes()));
         }
         if (ref.isBefore(sunsetTime)) {
             // before sunset
-            ev.addProperty("beforeSunset", Long.toString(toSunset.getStandardMinutes()));
+            ev.addProperty("beforeSunset", Long.toString(toSunset.toMinutes()));
         } else if (ref.isAfter(sunsetTime)) {
             // after sunset
-            ev.addProperty("afterSunset", Long.toString(toSunset.getStandardMinutes()));
+            ev.addProperty("afterSunset", Long.toString(toSunset.toMinutes()));
         }
         return ev;
     }

--- a/plugins/devices/twilight/src/main/java/com/freedomotic/plugins/devices/twilight/WeatherInfo.java
+++ b/plugins/devices/twilight/src/main/java/com/freedomotic/plugins/devices/twilight/WeatherInfo.java
@@ -19,7 +19,7 @@
  */
 package com.freedomotic.plugins.devices.twilight;
 
-import org.joda.time.DateTime;
+import java.time.ZonedDateTime;
 
 
 /**
@@ -32,13 +32,13 @@ public interface WeatherInfo {
      *
      * @return
      */
-    DateTime getNextSunset();
+    ZonedDateTime getNextSunset();
 
     /**
      *
      * @return
      */
-    DateTime getNextSunrise();
+    ZonedDateTime getNextSunrise();
 
     /**
      *
@@ -50,12 +50,12 @@ public interface WeatherInfo {
      *
      * @param sunset
      */
-    void setNextSunset(DateTime sunset);
+    void setNextSunset(ZonedDateTime sunset);
 
     /**
      *
      * @param sunrise
      */
-    void setNextSunrise(DateTime sunrise);
+    void setNextSunrise(ZonedDateTime sunrise);
 
 }

--- a/plugins/devices/twilight/src/test/java/com/freedomotic/plugins/devices/twilight/TwilightTest.java
+++ b/plugins/devices/twilight/src/test/java/com/freedomotic/plugins/devices/twilight/TwilightTest.java
@@ -20,10 +20,13 @@
  */
 
 package com.freedomotic.plugins.devices.twilight;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
 import com.freedomotic.events.GenericEvent;
 import com.freedomotic.plugins.devices.twilight.providers.EarthToolsWI;
 import com.freedomotic.plugins.devices.twilight.providers.OpenWeatherMapWI;
-import org.joda.time.DateTime;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -59,10 +62,10 @@ public class TwilightTest {
     
     @Test
     public void NoonTest() {
-        provider.setNextSunrise(new DateTime(2013, 11, 20, 5, 0));
-        provider.setNextSunset(new DateTime(2013, 11, 20, 17, 0));
+        provider.setNextSunrise(dateTime(2013, 11, 20, 5, 0));
+        provider.setNextSunset(dateTime(2013, 11, 20, 17, 0));
         
-        DateTime noon = new DateTime(2013, 11, 21, 12, 0);
+        ZonedDateTime noon = dateTime(2013, 11, 21, 12, 0);
         GenericEvent twAtNoon = twu.prepareEvent(noon);
         Assert.assertEquals("300", twAtNoon.getProperty("beforeSunset"));
         Assert.assertEquals("", twAtNoon.getProperty("afterSunset"));
@@ -71,7 +74,7 @@ public class TwilightTest {
         Assert.assertEquals("420", twAtNoon.getProperty("afterSunrise"));
         Assert.assertEquals("", twAtNoon.getProperty("beforeSunrise"));
         
-        noon = new DateTime(2013, 11, 21, 12, 1);
+        noon = dateTime(2013, 11, 21, 12, 1);
         twAtNoon = twu.prepareEvent(noon);
         Assert.assertEquals("299", twAtNoon.getProperty("beforeSunset"));
         Assert.assertEquals("", twAtNoon.getProperty("afterSunset"));
@@ -83,10 +86,10 @@ public class TwilightTest {
 
     @Test
     public void MidnightTest() {
-        provider.setNextSunrise(new DateTime(2013, 11, 20, 5, 0));
-        provider.setNextSunset(new DateTime(2013, 11, 20, 17, 0));
+        provider.setNextSunrise(dateTime(2013, 11, 20, 5, 0));
+        provider.setNextSunset(dateTime(2013, 11, 20, 17, 0));
         
-        DateTime midnight = new DateTime(2013, 11, 22, 0, 0);
+        ZonedDateTime midnight = dateTime(2013, 11, 22, 0, 0);
         GenericEvent twAtMidnight = twu.prepareEvent(midnight);
         Assert.assertEquals("", twAtMidnight.getProperty("beforeSunset"));
         Assert.assertEquals("420", twAtMidnight.getProperty("afterSunset"));
@@ -99,10 +102,10 @@ public class TwilightTest {
 
     @Test
     public void sunriseTest() {
-        provider.setNextSunrise(new DateTime(2013, 11, 20, 5, 0));
-        provider.setNextSunset(new DateTime(2013, 11, 20, 17, 0));
+        provider.setNextSunrise(dateTime(2013, 11, 20, 5, 0));
+        provider.setNextSunset(dateTime(2013, 11, 20, 17, 0));
         
-        DateTime sunrise = new DateTime(2013, 11, 20, 5, 0);
+        ZonedDateTime sunrise = dateTime(2013, 11, 20, 5, 0);
         GenericEvent twAtSunrise = twu.prepareEvent(sunrise);
         Assert.assertEquals("720", twAtSunrise.getProperty("beforeSunset"));
         Assert.assertEquals("", twAtSunrise.getProperty("afterSunset"));
@@ -111,7 +114,7 @@ public class TwilightTest {
         Assert.assertEquals("", twAtSunrise.getProperty("afterSunrise"));
         Assert.assertEquals("", twAtSunrise.getProperty("beforeSunrise"));
         
-        sunrise = new DateTime(2013, 11, 20, 5, 1);
+        sunrise = dateTime(2013, 11, 20, 5, 1);
         twAtSunrise = twu.prepareEvent(sunrise);
         Assert.assertEquals("719", twAtSunrise.getProperty("beforeSunset"));
         Assert.assertEquals("", twAtSunrise.getProperty("afterSunset"));
@@ -123,10 +126,10 @@ public class TwilightTest {
 
     @Test
     public void sunsetTest() {
-        provider.setNextSunrise(new DateTime(2013, 11, 20, 5, 0));
-        provider.setNextSunset(new DateTime(2013, 11, 20, 17, 0));
+		provider.setNextSunrise(dateTime(2013, 11, 20, 5, 0));
+        provider.setNextSunset(dateTime(2013, 11, 20, 17, 0));
         
-        DateTime sunset = new DateTime(2013,11,23, 17,0);
+        ZonedDateTime sunset = dateTime(2013, 11, 23, 17, 0);
         GenericEvent twAtSunset = twu.prepareEvent(sunset);
         Assert.assertEquals("", twAtSunset.getProperty("beforeSunset"));
         Assert.assertEquals("", twAtSunset.getProperty("afterSunset"));
@@ -135,7 +138,7 @@ public class TwilightTest {
         Assert.assertEquals("720", twAtSunset.getProperty("afterSunrise"));
         Assert.assertEquals("", twAtSunset.getProperty("beforeSunrise"));
         
-        DateTime postSunset = new DateTime(2013, 11, 23, 17, 1);
+        ZonedDateTime postSunset = dateTime(2013, 11, 23, 17, 1);
         GenericEvent twPostSunset = twu.prepareEvent(postSunset);
         Assert.assertEquals("", twPostSunset.getProperty("beforeSunset"));
         Assert.assertEquals("1", twPostSunset.getProperty("afterSunset"));
@@ -143,5 +146,9 @@ public class TwilightTest {
         Assert.assertEquals("", twPostSunset.getProperty("isSunrise"));
         Assert.assertEquals("", twPostSunset.getProperty("afterSunrise"));
         Assert.assertEquals("719", twPostSunset.getProperty("beforeSunrise"));
+    }
+
+    private static ZonedDateTime dateTime(int year, int month, int day, int hour, int minute) {
+        return ZonedDateTime.of(year, month, day, hour, minute, 0, 0, ZoneId.systemDefault());
     }
 }


### PR DESCRIPTION
Fixes #417

I was looking for something to contribute for HacktoberFest, and came across this issue.

I switched the code to use the equivalent Java8 time classes from the Joda classes used.  As well as ensuring the tests passed, I inspected the output from `TwighlightTest.updateTest`.  I ran the tests using `TZ=Europe/Rome mvn clean test` as that matched the location used in the test.

The test for EarthToolsWI was fine, as this gave the same results:
before:
```Sunrise at: 2018-10-14T07:13:24.000+02:00 Sunset at: 2018-10-14T18:58:25.000+02:00```
after:
```Sunrise: 2018-10-14T07:13:24+02:00[Europe/Rome] - Sunset: 2018-10-14T18:58:25+02:00[Europe/Rome]```

However, for OpenWeatherMapWI this gave different results:
before:
```Sunrise at: 2018-10-14T06:29:26.000+02:00 Sunset at: 2018-10-14T17:33:24.000+02:00```
after
```Sunrise: 2018-10-14T07:29:26+02:00[Europe/Rome] - Sunset: 2018-10-14T18:33:23+02:00[Europe/Rome]```

I'm not clear on how I introduced a difference in the response, but I believe the new output is correct. The API response includes:
```<sun rise="2018-10-14T05:29:43" set="2018-10-14T16:33:00"/>```

These times are UTC, and as Italy is currently at UTC+2 (with daylight saving), the displayed times following my change are correct for the timezone.
